### PR TITLE
[Registration] Call update_mailchimp on user update

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -32,6 +32,6 @@ class Admin::UsersController < AdminController
   private
 
   def user_params
-    params.require(:user).permit(:name, :email, :admin, :early_access)
+    params.require(:user).permit(:name, :email, :admin, :early_access, :marketing_opt_in)
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,5 +1,6 @@
 class Users::RegistrationsController < Devise::RegistrationsController
   prepend_before_action :check_captcha, only: [:create]
+  before_action :configure_permitted_parameters, if: :devise_controller?
 
   private
 
@@ -16,7 +17,40 @@ class Users::RegistrationsController < Devise::RegistrationsController
     end
   end
 
+  def update_resource(resource, params)
+    result = resource.update_with_password(params)
+    resource.update_mailchimp
+    result
+  end
+
   protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(
+      :sign_up,
+      keys: %i[
+        name
+        accept_principles
+        marketing_opt_in
+        accept_emails
+        accept_no_ticket
+        accept_code_of_conduct
+        accept_health_and_safety
+      ]
+    )
+
+    devise_parameter_sanitizer.permit(
+      :account_update,
+      keys: %i[
+        name
+        email
+        password
+        password_confirmation
+        current_password
+        marketing_opt_in
+      ]
+    )
+  end
 
   def after_inactive_sign_up_path_for(_resource)
     confirmation_notice_path

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -3,6 +3,7 @@
   <%= form.text_field :email %>
   <%= form.check_box :admin %>
   <%= form.check_box :early_access %>
+  <%= form.check_box :marketing_opt_in %>
   <%= form.submit 'Update user details' %>
 <% end %>
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -42,4 +42,8 @@
   </div>
 <% end %>
 
-<%= button_to t('.cancel_my_account'), registration_path(resource_name), data: { confirm: t('.are_you_sure') }, method: :delete, class: "btn btn-danger" %>
+<div class="mb-3">
+  <%= button_to t('.cancel_my_account'), registration_path(resource_name), data: { confirm: t('.are_you_sure') }, method: :delete, class: "btn btn-danger" %>
+</div>
+
+<%= button_to "Back", :back, class: "btn btn-secondary"  %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -33,10 +33,13 @@
   </div>
 
   <div class="form-group mb-3">
+    <%= f.label :marketing_opt_in %>
+    <%= f.check_box :marketing_opt_in %>
+  </div>
+
+  <div class="form-group mb-3">
     <%= f.submit t('.update'), class: 'btn btn-primary' %>
   </div>
 <% end %>
 
-<p><%= link_to t('.cancel_my_account'), registration_path(resource_name), data: { confirm: t('.are_you_sure') }, method: :delete %>.</p>
-
-<%= link_to t('.back'), :back %>
+<%= button_to t('.cancel_my_account'), registration_path(resource_name), data: { confirm: t('.are_you_sure') }, method: :delete, class: "btn btn-danger" %>

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -30,15 +30,24 @@ RSpec.describe User, type: :model do
                        'merge_fields': { 'NAME': 'James Darling' }
                      }
                    )
-      @tag_stub = stub_request(:post, 'https://us3.api.mailchimp.com/3.0/lists/1234/members/2585df46821f60e7ea95e8cb7f495623/tags')
-                  .with(
-                    body: {
-                      'tags': [
-                        { 'name': 'member', 'status': 'active' },
-                        { 'name': 'member-marketing', 'status': 'inactive' }
-                      ]
-                    }
-                  )
+      @full_tag_stub = stub_request(:post, 'https://us3.api.mailchimp.com/3.0/lists/1234/members/2585df46821f60e7ea95e8cb7f495623/tags')
+                       .with(
+                         body: {
+                           'tags': [
+                             { 'name': 'member', 'status': 'active' },
+                             { 'name': 'member-marketing', 'status': 'active' }
+                           ]
+                         }
+                       )
+      @member_only_tag_stub = stub_request(:post, 'https://us3.api.mailchimp.com/3.0/lists/1234/members/2585df46821f60e7ea95e8cb7f495623/tags')
+                              .with(
+                                body: {
+                                  'tags': [
+                                    { 'name': 'member', 'status': 'active' },
+                                    { 'name': 'member-marketing', 'status': 'inactive' }
+                                  ]
+                                }
+                              )
     end
 
     it 'should create a user on Mailchimp' do
@@ -47,10 +56,16 @@ RSpec.describe User, type: :model do
       expect(@user_stub).to have_been_requested
     end
 
-    it 'should create tag the user on Mailchimp' do
-      new_user = create(:user, email: 'james@abscond.org', name: 'James Darling')
+    it 'should create both tags on the user on Mailchimp' do
+      new_user = create(:user, email: 'james@abscond.org', name: 'James Darling', marketing_opt_in: true)
       new_user.update_mailchimp
-      expect(@tag_stub).to have_been_requested
+      expect(@full_tag_stub).to have_been_requested
+    end
+
+    it 'should create only member tag the user on Mailchimp' do
+      new_user = create(:user, email: 'james@abscond.org', name: 'James Darling', marketing_opt_in: false)
+      new_user.update_mailchimp
+      expect(@member_only_tag_stub).to have_been_requested
     end
   end
 end


### PR DESCRIPTION
There is currently no way for the user to re-sign up for marketing emails, this re-adds that feature in both the normal profile page, as well as the admin page for users.

I did modify some styles and bits but those changes are minimal and more for spacing than anything