### PR TITLE
[Volunteer] Prevent an empty role being created

### DIFF
--- a/app/models/volunteer_role.rb
+++ b/app/models/volunteer_role.rb
@@ -1,6 +1,11 @@
 class VolunteerRole < ApplicationRecord
   belongs_to :event
   has_many :volunteers, dependent: :destroy
+
+  validates :name, presence: true
+  validates :brief_description, presence: true
+  validates :description, presence: true
+
   scope :available_for_user, lambda { |user|
     where.not(id: user.volunteers.pluck(:volunteer_role_id))
          .order(:priority)

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -29,6 +29,7 @@ FactoryBot.define do
   factory :volunteer_role do
     name { 'MyString' }
     description { 'MyText' }
+    brief_description { 'MyText' }
     event
   end
 

--- a/spec/features/admin/volunteer_roles_spec.rb
+++ b/spec/features/admin/volunteer_roles_spec.rb
@@ -24,6 +24,17 @@ RSpec.feature 'Volunteer Roles Admin', type: :feature do
     expect(page).to have_content('10')
   end
 
+  scenario 'validation prevents creating a blank role' do
+    login(admin: true)
+    create(:event)
+    click_link 'Events'
+    click_link 'London Decompression 2019'
+    click_link 'Volunteer Roles'
+    click_link 'Add new'
+    click_button 'Create Volunteer Role'
+    expect(page).to have_content('can\'t be blank')
+  end
+
   scenario 'editing a role' do
     login(admin: true)
     create(:volunteer_role, name: 'Role1', description: 'First Role')


### PR DESCRIPTION
Really simple just prevents any empty events from being created in the system!