### PR TITLE
[Style] Replace devise-bootstrap-views with custom solution

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'rubocop', '0.74'
 gem 'rollbar'
 
 gem 'devise'
-gem 'devise-bootstrap-views', '~> 1.0'
+gem 'devise-i18n'
 
 gem 'bootstrap'
 gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,7 +114,8 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
-    devise-bootstrap-views (1.1.0)
+    devise-i18n (1.10.3)
+      devise (>= 4.8.0)
     diff-lcs (1.5.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
@@ -398,7 +399,7 @@ DEPENDENCIES
   climate_control
   coffee-rails (~> 4.2)
   devise
-  devise-bootstrap-views (~> 1.0)
+  devise-i18n
   dotenv-rails
   eventbrite_sdk
   factory_bot_rails

--- a/config/initializers/custom_modules.rb
+++ b/config/initializers/custom_modules.rb
@@ -1,0 +1,3 @@
+require 'devise_bootstrap_views_helper'
+
+ActionView::Base.send :include, DeviseBootstrapViewsHelper

--- a/lib/devise_bootstrap_views_helper.rb
+++ b/lib/devise_bootstrap_views_helper.rb
@@ -1,0 +1,24 @@
+module DeviseBootstrapViewsHelper
+  def bootstrap_devise_error_messages!
+    return '' if resource.errors.empty?
+
+    messages = resource.errors.full_messages.map { |message| content_tag(:li, message) }.join
+    sentence = I18n.t(
+      'errors.messages.not_saved',
+      count: resource.errors.count,
+      resource: resource.class.model_name.human.downcase
+    )
+
+    html = <<-HTML
+    <div class="alert alert-danger alert-dismissible fade show" role="alert">
+      <h4 class="alert-heading">#{sentence}</h4>
+      <ul class="mb-0">#{messages}</ul>
+      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+    HTML
+
+    html.html_safe
+  end
+
+  module_function :bootstrap_devise_error_messages!
+end


### PR DESCRIPTION
`devise-bootstrap-views` is unmaintained and doesn't support past bootstrap 4 so this means we now do, and allows us to fix that bloody broken styling on the close button for the alerts!!!!!!!

We have to use the `devise-i18n` package as previously `devise-bootstrap-views` was covering that for us