### PR TITLE
Allowing for users to be deleted from both the members site AND mailchimp

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -23,6 +23,12 @@ class Admin::UsersController < AdminController
     redirect_to action: :index
   end
 
+  def destroy
+    @user = User.find(params[:id])
+    @user.destroy
+    redirect_to action: :index
+  end
+
   def give_direct_sale
     @user = User.find(params[:id])
     direct_sale_code = DirectSaleCode.available.first

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -29,11 +29,6 @@ class Admin::UsersController < AdminController
     redirect_to action: :index
   end
 
-  def resend_email
-    @user = User.find(params[:id])
-    @user.resend_confirmation_instructions
-  end
-
   def give_direct_sale
     @user = User.find(params[:id])
     direct_sale_code = DirectSaleCode.available.first

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -29,6 +29,11 @@ class Admin::UsersController < AdminController
     redirect_to action: :index
   end
 
+  def resend_email
+    @user = User.find(params[:id])
+    @user.resend_confirmation_instructions
+  end
+
   def give_direct_sale
     @user = User.find(params[:id])
     direct_sale_code = DirectSaleCode.available.first

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -19,6 +19,7 @@ class Admin::UsersController < AdminController
   def update
     @user = User.find(params[:id])
     @user.update!(user_params)
+    @user.update_mailchimp
     redirect_to action: :index
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -92,8 +92,8 @@ class User < ApplicationRecord
     Rollbar.error(e)
   end
 
-  def has_confirmation_period_expired?
-    confirmation_period_expired?
+  def confirmation_period_expired?
+    super
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -67,7 +67,12 @@ class User < ApplicationRecord
     # that later on, this is more important
     gibbon.lists(list_id).members(email_hash).actions.delete_permanent.create
   rescue Gibbon::MailChimpError => e
-    Rollbar.error(e)
+    # Note: the reason for this is even if we check if the user exists, we'd get
+    #       a 404 response from MailChimp and whilst we shouldn't exclude errors
+    #       there is little benefit to reporting this error
+    if e.status_code != 404
+      Rollbar.error(e)
+    end
   end
 
   def update_mailchimp

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -92,6 +92,10 @@ class User < ApplicationRecord
     Rollbar.error(e)
   end
 
+  def has_confirmation_period_expired?
+    confirmation_period_expired?
+  end
+
   private
 
   def set_membership_code

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -7,6 +7,10 @@
   <%= form.submit 'Update user details' %>
 <% end %>
 
+<div class="mt-3">
+  <%= button_to 'Delete', admin_user_path(@user), method: :delete, data: {confirm: 'Are you sure? This is irreversible'}, class: "btn btn-danger" %>
+</div>
+
 <hr>
 
 <% if @user.ticket_type == :direct %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,6 +1,6 @@
 <h2>Members</h2>
 
-<p>There is currently <%= pluralize(@users.count, 'member') %></p>
+<p>There is currently <%= pluralize(User.confirmed.count, 'member') %></p>
 
 <%= form_tag nil, method: :get do %>
   <%= text_field_tag :q, params[:q] %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,6 +1,6 @@
 <h2>Members</h2>
 
-<p>There are currently <%= User.confirmed.count %> members</p>
+<p>There is currently <%= pluralize(@users.count, 'member') %></p>
 
 <%= form_tag nil, method: :get do %>
   <%= text_field_tag :q, params[:q] %>

--- a/app/views/admin/users/unconfirmed.html.erb
+++ b/app/views/admin/users/unconfirmed.html.erb
@@ -1,19 +1,27 @@
 <h2>Unconfirmed Members</h2>
 
-<p>There are currently <%= @users.count %> members</p>
+<p>There is currently <%= pluralize(@users.count, 'unconfirmed member') %></p>
 
 <table class="table">
   <tr>
     <th>Name</th>
     <th>Email</th>
-    <th>Confirmation Link</th>
+    <th>Unconfirmed Duration</th>
+    <th>Resend Confirmation</th>
     <th>Delete</th>
   </tr>
   <% @users.each do |user| %>
     <tr>
       <td><%= user.name %></td>
       <td><%= user.email %></td>
-      <td><%= link_to 'Link', confirmation_url(user, confirmation_token: user.confirmation_token) %></td>
+      <td><%= distance_of_time_in_words(user.created_at.to_time - Time.now) %></td>
+      <td>
+        <% if user.has_confirmation_period_expired? %>
+          <%= button_to 'Resend Confirmation', resend_email_admin_user_path(user), method: :post %>
+        <% else %>
+          Last confirmation sent <%= distance_of_time_in_words(user.confirmation_sent_at.to_time - Time.now) %> ago
+        <% end %>
+      </td>
       <td><%= button_to 'Delete', admin_user_path(user), method: :delete, data: {confirm: 'Are you sure? This is irreversible'}, class: "btn btn-danger" %></td>
     </tr>
   <% end %>

--- a/app/views/admin/users/unconfirmed.html.erb
+++ b/app/views/admin/users/unconfirmed.html.erb
@@ -16,7 +16,7 @@
       <td><%= user.email %></td>
       <td><%= distance_of_time_in_words(user.created_at.to_time - Time.now) %></td>
       <td>
-        <% if user.has_confirmation_period_expired? %>
+        <% if user.confirmation_period_expired? %>
           <%= button_to 'Resend Confirmation', resend_email_admin_user_path(user), method: :post %>
         <% else %>
           Last confirmation sent <%= distance_of_time_in_words(user.confirmation_sent_at.to_time - Time.now) %> ago

--- a/app/views/admin/users/unconfirmed.html.erb
+++ b/app/views/admin/users/unconfirmed.html.erb
@@ -7,7 +7,7 @@
     <th>Name</th>
     <th>Email</th>
     <th>Unconfirmed Duration</th>
-    <th>Resend Confirmation</th>
+    <th>Confirmation Info</th>
     <th>Delete</th>
   </tr>
   <% @users.each do |user| %>
@@ -16,11 +16,7 @@
       <td><%= user.email %></td>
       <td><%= distance_of_time_in_words(user.created_at.to_time - Time.now) %></td>
       <td>
-        <% if user.confirmation_period_expired? %>
-          <%= button_to 'Resend Confirmation', resend_email_admin_user_path(user), method: :post %>
-        <% else %>
-          Last confirmation sent <%= distance_of_time_in_words(user.confirmation_sent_at.to_time - Time.now) %> ago
-        <% end %>
+        Last confirmation sent <%= distance_of_time_in_words(user.confirmation_sent_at.to_time - Time.now) %> ago
       </td>
       <td><%= button_to 'Delete', admin_user_path(user), method: :delete, data: {confirm: 'Are you sure? This is irreversible'}, class: "btn btn-danger" %></td>
     </tr>

--- a/app/views/admin/users/unconfirmed.html.erb
+++ b/app/views/admin/users/unconfirmed.html.erb
@@ -7,12 +7,14 @@
     <th>Name</th>
     <th>Email</th>
     <th>Confirmation Link</th>
+    <th>Delete</th>
   </tr>
   <% @users.each do |user| %>
     <tr>
       <td><%= user.name %></td>
       <td><%= user.email %></td>
       <td><%= link_to 'Link', confirmation_url(user, confirmation_token: user.confirmation_token) %></td>
+      <td><%= button_to 'Delete', admin_user_path(user), method: :delete, data: {confirm: 'Are you sure? This is irreversible'}, class: "btn btn-danger" %></td>
     </tr>
   <% end %>
 </table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,6 @@ Rails.application.routes.draw do
       end
       member do
         patch :give_direct_sale
-        post :resend_email
       end
     end
     resources :membership_codes

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
       end
       member do
         patch :give_direct_sale
+        post :resend_email
       end
     end
     resources :membership_codes

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -95,7 +95,8 @@ RSpec.describe User, type: :model do
                                   ]
                                 }
                               )
-      @deleted_stub = stub_request(:post, 'https://us3.api.mailchimp.com/3.0/lists/1234/members/2585df46821f60e7ea95e8cb7f495623/actions/delete-permanent').with(body: "null")
+      @deleted_stub = stub_request(:post, 'https://us3.api.mailchimp.com/3.0/lists/1234/members/2585df46821f60e7ea95e8cb7f495623/actions/delete-permanent')
+                      .with(body: 'null')
     end
 
     it 'should delete a user on Mailchimp' do


### PR DESCRIPTION
Not only can users now delete their accounts and it will delete the mailchimp user too, as these steps typically happen together, admins can now delete the users.

Removed the ability to confirm accounts and replaced with when the confirmation email was sent, to make the button to re-send appear the value of `confirm_within` to be anything but `nil` then after the duration given e.g. if it was set to 24 hours, after that point, you'd be able to force the system to re-send the confirmation emails.

Note: When we go to delete a user, if they have not gone into MailChimp we don't report the 404 into the error system (can remove this if needed)