### PR TITLE
Volunteering Changes

### DIFF
--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -45,7 +45,12 @@ class VolunteersController < ApplicationController
     @volunteer = @volunteer_role.volunteers.find(params[:id])
     @volunteer.destroy
     flash[:notice] = "#{@volunteer.user.name} has been removed as a volunteer"
-    redirect_to event_volunteer_role_volunteers_path(@event, @volunteer_role)
+
+    if current_user.lead_for?(@volunteer_role)
+      redirect_to event_volunteer_role_volunteers_path(@event, @volunteer_role)
+    else
+      redirect_to root_path
+    end
   end
 
   def volunteer_cancelling

--- a/app/views/admin/volunteers/index.html.erb
+++ b/app/views/admin/volunteers/index.html.erb
@@ -17,7 +17,7 @@
 
 <%= bootstrap_form_for [:admin, @event, @volunteer_role, Volunteer.new] do |form| %>
   <%= form.select :user_id,
-                  User.pluck(:id, :name, :email).collect {|u| ["#{u[1]} (#{u[2]})", u[0]]},
+                  User.confirmed.pluck(:id, :name, :email).collect {|u| ["#{u[1]} (#{u[2]})", u[0]]},
                   {label: 'Find member to make a lead'},
                   {class: 'selectpicker', data: { 'live-search': 'true' }}
   %>

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -54,63 +54,8 @@
 
 <% if @event.tickets_sold_for_code(current_user.membership_number) > 0 %>
   <hr />
-  <% if current_user.volunteers_for_event(@event).any? %>
-    <h2>You've signed up to volunteer for:</h2>
-
-    <div class="list-group">
-      <% current_user.volunteers_for_event(@event).each do |volunteer| %>
-        <% cache volunteer do %>
-          <div class="list-group-item d-flex justify-content-between align-items-center">
-            <div>
-              <h5><%= volunteer.volunteer_role.name %></h5>
-              <% if volunteer.state == 'confirmed' %>
-                <p>You are confirmed as a volunteer</p>
-              <% elsif volunteer.state == 'contacted' %>
-                <p>You have been contacted by a lead</p>
-              <% else %>
-                <p>The leads for this role should be in contact with you very soon.</p>
-              <% end %>
-              <%= link_to 'Click here to remove yourself from this role', event_volunteer_role_volunteer_path(@event, volunteer.volunteer_role, volunteer), method: :delete, data: {confirm: 'Are you sure?'} %>
-              <% if volunteer.lead? %>
-                <p>
-                  You are a lead for this role:
-                  <%= link_to 'view volunteers', event_volunteer_role_volunteers_path(@event, volunteer.volunteer_role) %>
-                </p>
-              <% end %>
-            </div>
-          </div>
-        <% end %>
-      <% end %>
-
-      <hr />
-  <% end %>
-
-  <% if current_user.volunteers_for_event(@event).any? %>
-    <h2>Have you more to give?</h2>
-    <p>You can apply for more than one role if you like.</p>
-  <% else %>
-    <h2>Volunteer opportunities</h2>
-    <p>Congratulations, you've got your ticket for Decom!</p>
-    <p>Now, which team would you like to gift some of your time to? ;&#41;</p>
-  <% end %>
-
-  <div class="list-group">
-    <% @volunteer_roles.each do |volunteer_role| %>
-      <% cache volunteer_role do %>
-        <div class="row border">
-          <div class="col-8">
-            <h5><%= volunteer_role.name %></h5>
-            <%= simple_format volunteer_role.brief_description %>
-          </div>
-          <div class="col-4 d-flex justify-content-end" style="align-items: start; padding-top: 5px">
-            <a href="<%= new_event_volunteer_role_volunteer_path(@event, volunteer_role) %>" class="btn btn-primary">Volunteer</a>
-          </div>
-        </div>
-      <% end %>
-    <% end %>
-  </div>
-  <br />
-  <p>If you have any questions about volunteering, feel free to email <a href="mailto:volunteers@londondecom.org">volunteers@londondecom.org</a></p>
+  <%= render partial: 'volunteers/applied_list' %>
+  <%= render partial: 'volunteers/list' %>
 <% end %>
 
 <hr>

--- a/app/views/volunteers/_applied_list.html.erb
+++ b/app/views/volunteers/_applied_list.html.erb
@@ -1,0 +1,36 @@
+<% if current_user.volunteers_for_event(@event).any? %>
+  <h2>You've signed up to volunteer for:</h2>
+
+  <div class="list-group">
+    <% current_user.volunteers_for_event(@event).each do |volunteer| %>
+      <% cache volunteer do %>
+        <div class="list-group-item">
+          <div class="row">
+            <div class="col-md-8 col-12">
+              <h5><%= volunteer.volunteer_role.name %></h5>
+              <% if volunteer.state == 'confirmed' %>
+                <p>You are confirmed as a volunteer</p>
+              <% elsif volunteer.state == 'contacted' %>
+                <p>You have been contacted by a lead</p>
+              <% else %>
+                <% if volunteer.lead? %>
+                  <p>As you are the lead for this role, please get in contact with those who have applied as soon as possible!</p>
+                <% else %>
+                  <p>The leads for this role should be in contact with you very soon.</p>
+                <% end %>
+              <% end %>
+            </div>
+            <div class="col-md-4 col-12 d-flex justify-content-md-end justify-content-center align-items-center" style="align-items: start; padding-top: 5px">
+              <% if volunteer.lead? %>
+                <%= link_to 'View Volunteers', event_volunteer_role_volunteers_path(@event, volunteer.volunteer_role), class: "btn btn-primary me-1"  %>
+              <% end %>
+              <%= link_to 'Un-Volunteer', event_volunteer_role_volunteer_path(@event, volunteer.volunteer_role, volunteer), method: :delete, data: {confirm: 'Are you sure?'}, class: "btn btn-danger" %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    <% end %>
+
+    <hr />
+  </div>
+<% end %>

--- a/app/views/volunteers/_list.html.erb
+++ b/app/views/volunteers/_list.html.erb
@@ -1,0 +1,30 @@
+<% if @volunteer_roles.any? %>
+  <% if current_user.volunteers_for_event(@event).any? %>
+    <h2>Have you more to give?</h2>
+    <p>You can apply for more than one role if you like.</p>
+  <% else  %>
+    <h2>Volunteer opportunities</h2>
+    <p>Congratulations, you've got your ticket for Decom!</p>
+    <p>Now, which team would you like to gift some of your time to? ;&#41;</p>
+  <% end %>
+
+  <div class="list-group">
+    <% @volunteer_roles.each do |volunteer_role| %>
+      <% cache volunteer_role do %>
+        <div class="list-group-item d-flex justify-content-between align-items-center">
+          <div class="col-8">
+            <h5><%= volunteer_role.name %></h5>
+            <%= simple_format volunteer_role.brief_description %>
+          </div>
+          <div class="col-4 d-flex justify-content-end" style="align-items: start; padding-top: 5px">
+            <a href="<%= new_event_volunteer_role_volunteer_path(@event, volunteer_role) %>" class="btn btn-primary">Volunteer</a>
+          </div>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+  <br />
+  <p>If you have any questions about volunteering, feel free to email <a href="mailto:volunteers@londondecom.org">volunteers@londondecom.org</a></p>
+
+  <hr>
+<% end %>

--- a/app/views/volunteers/index.html.erb
+++ b/app/views/volunteers/index.html.erb
@@ -17,6 +17,7 @@
     <th>Phone</th>
     <th>Comments</th>
     <th>State</th>
+    <th>Next State</th>
     <th></th>
   </tr>
   <% @volunteers.each do |volunteer| %>
@@ -28,6 +29,8 @@
         <td><%= volunteer.additional_comments %></td>
         <td>
           <%= volunteer.state %>
+        </td>
+        <td>
           <% if volunteer.next_state %>
             <%= form_for [@event, @volunteer_role, volunteer] do |form| %>
               <%= form.hidden_field :state, value: volunteer.next_state %>

--- a/spec/features/volunteer_leads_spec.rb
+++ b/spec/features/volunteer_leads_spec.rb
@@ -11,8 +11,8 @@ RSpec.feature 'Volunteering leads', type: :feature do
     create(:volunteer, volunteer_role: role, user: @user, lead: true)
 
     visit root_path
-    expect(page).to have_content('You are a lead for this role')
-    click_link 'view volunteers'
+    expect(page).to have_content('As you are the lead for this role')
+    click_link 'View Volunteers'
     expect(page).to have_content(volunteer1.email)
     expect(page).to have_content(volunteer2.email)
     expect(page).to_not have_content(not_a_volunteer.email)
@@ -67,8 +67,21 @@ RSpec.feature 'Volunteering leads', type: :feature do
     role = create(:volunteer_role, name: 'Ranger', description: 'A description of rangering')
     create(:volunteer, volunteer_role: role, user: @user, lead: false)
     visit root_path
-    expect(page).to_not have_content('You are a lead for this role')
+    expect(page).to_not have_content('As you are the lead for this role')
     visit event_volunteer_role_volunteers_path(role.event, role)
     expect(page).to have_text('You are not permitted to view this')
+  end
+
+  scenario 'viewing the volunteers after removing self as lead' do
+    stub_eventbrite_event(tickets_sold_for_code: 1)
+    login
+    role = create(:volunteer_role, name: 'Ranger', description: 'A description of rangering')
+    create(:volunteer, volunteer_role: role, user: @user, lead: true)
+
+    visit root_path
+    click_link 'View Volunteers'
+    visit root_path
+    click_link 'Un-Volunteer'
+    expect(page).to_not have_text("You've signed up to volunteer for:")
   end
 end

--- a/spec/features/volunteer_spec.rb
+++ b/spec/features/volunteer_spec.rb
@@ -48,7 +48,7 @@ RSpec.feature 'Volunteering', type: :feature do
     create(:volunteer, user: @user, volunteer_role:)
 
     visit root_path
-    click_link 'Click here to remove yourself from this role'
+    click_link 'Un-Volunteer'
     expect(page).to have_content('You are no longer volunteering for Ranger')
     expect(@user.volunteers.count).to eq(0)
 


### PR DESCRIPTION
No request given for this.

Cleanup to the volunteering pages, extracting parts into partials so layout is cleaner as well as changes to some of the wording and button styling to make it feel better.

Fixed a small issue with a redirect, where if you removed yourself as a volunteer role, and were the lead, then you'd end up being shown the lead of volunteers again, instead of being redirected to the home page.

Same now applies for if you have the URL and try visit it but are not the lead of the volunteer role.

There is caching added as well, this is safe, as it respects HTML changes and if you volunteer for something, it does get removed from the view, and added correctly to the applied roles. Same in reverse works, unvolunteering for a role removes it from the applied for section and shows up in the possible volunteer roles area.

Added to save on some generation time, no point re-generating the same HTML for every user applied or not