### PR TITLE
Reconfirmation

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -23,6 +23,12 @@ class Admin::UsersController < AdminController
     redirect_to action: :index
   end
 
+  def resend_email
+    @user = User.find(params[:id])
+    @user.resend_confirmation_instructions
+    redirect_to action: :unconfirmed
+  end
+
   def destroy
     @user = User.find(params[:id])
     @user.destroy

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -9,7 +9,12 @@ class Admin::UsersController < AdminController
   end
 
   def unconfirmed
-    @users = User.unconfirmed.order(created_at: :desc)
+    if params[:q]
+      q = "%#{params[:q]}%"
+      @users = User.unconfirmed.where('name ILIKE ? OR email ILIKE ?', q, q).order(:created_at).page params[:page]
+    else
+      @users = User.unconfirmed.order(:created_at).page params[:page]
+    end
   end
 
   def edit

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -94,10 +94,6 @@ class User < ApplicationRecord
     Rollbar.error(e)
   end
 
-  def confirmation_period_expired?
-    super
-  end
-
   private
 
   def set_membership_code

--- a/app/views/admin/users/unconfirmed.html.erb
+++ b/app/views/admin/users/unconfirmed.html.erb
@@ -19,13 +19,9 @@
     <tr>
       <td><%= user.name %></td>
       <td><%= user.email %></td>
-      <td><%= distance_of_time_in_words(Time.zone.now - user.created_at.to_time) %></td>
+      <td><%= distance_of_time_in_words(user.created_at.to_time - Time.zone.now) %></td>
       <td>
-        <% if user.confirmation_period_expired? %>
-          <%= button_to 'Resend', resend_email_admin_user_path(user), method: :post, class: "btn btn-primary" %>
-        <% else %>
-          Last confirmation sent <%= distance_of_time_in_words(user.confirmation_sent_at.to_time - Time.zone.now) %> ago
-        <% end %>
+        <%= button_to 'Resend', resend_email_admin_user_path(user), method: :post, class: "btn btn-primary" %>
       </td>
       <td><%= button_to 'Delete', admin_user_path(user), method: :delete, data: {confirm: 'Are you sure? This is irreversible'}, class: "btn btn-danger" %></td>
     </tr>

--- a/app/views/admin/users/unconfirmed.html.erb
+++ b/app/views/admin/users/unconfirmed.html.erb
@@ -2,6 +2,11 @@
 
 <p>There are currently <%= pluralize(@users.count, 'unconfirmed member') %></p>
 
+<%= form_tag nil, method: :get do %>
+  <%= text_field_tag :q, params[:q] %>
+  <%= submit_tag 'Search' %>
+<% end %>
+
 <table class="table">
   <tr>
     <th>Name</th>

--- a/app/views/admin/users/unconfirmed.html.erb
+++ b/app/views/admin/users/unconfirmed.html.erb
@@ -1,6 +1,6 @@
 <h2>Unconfirmed Members</h2>
 
-<p>There is currently <%= pluralize(@users.count, 'unconfirmed member') %></p>
+<p>There are currently <%= pluralize(@users.count, 'unconfirmed member') %></p>
 
 <table class="table">
   <tr>
@@ -14,9 +14,13 @@
     <tr>
       <td><%= user.name %></td>
       <td><%= user.email %></td>
-      <td><%= distance_of_time_in_words(user.created_at.to_time - Time.now) %></td>
+      <td><%= distance_of_time_in_words(Time.zone.now - user.created_at.to_time) %></td>
       <td>
-        Last confirmation sent <%= distance_of_time_in_words(user.confirmation_sent_at.to_time - Time.now) %> ago
+        <% if user.confirmation_period_expired? %>
+          <%= button_to 'Resend', resend_email_admin_user_path(user), method: :post, class: "btn btn-primary" %>
+        <% else %>
+          Last confirmation sent <%= distance_of_time_in_words(user.confirmation_sent_at.to_time - Time.zone.now) %> ago
+        <% end %>
       </td>
       <td><%= button_to 'Delete', admin_user_path(user), method: :delete, data: {confirm: 'Are you sure? This is irreversible'}, class: "btn btn-danger" %></td>
     </tr>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -139,7 +139,7 @@ Devise.setup do |config|
   # their account can't be confirmed with the token any more.
   # Default is nil, meaning there is no restriction on how long a user can take
   # before confirming their account.
-  # config.confirm_within = 3.days
+  config.confirm_within = 24.hours
 
   # If true, requires any email changes to be confirmed (exactly the same way as
   # initial account confirmation) to be applied. Requires additional unconfirmed_email

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -139,7 +139,7 @@ Devise.setup do |config|
   # their account can't be confirmed with the token any more.
   # Default is nil, meaning there is no restriction on how long a user can take
   # before confirming their account.
-  config.confirm_within = 24.hours
+  # config.confirm_within = 3.days
 
   # If true, requires any email changes to be confirmed (exactly the same way as
   # initial account confirmation) to be applied. Requires additional unconfirmed_email

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
       end
       member do
         patch :give_direct_sale
+        post :resend_email
       end
     end
     resources :membership_codes


### PR DESCRIPTION
Often requested button, along with the whole thing being paginated, being a bit closer to the confirmed user page.

Also made unconfirmed user searchable, not really needed but gives us a little benefit!

Timings might need to change but 24 hours seems pretty reasonable as this means the token expires after 24 hours, yes less than ideal to a level, but I know sites that make them last 15, so think we are good.