### PR TITLE
Low income windowing

### DIFF
--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -41,7 +41,8 @@ class Admin::EventsController < AdminController
       :name, :active,
       :ticket_sale_start_date, :theme, :theme_details, :theme_image_url,
       :location, :maps_location_url, :event_timings, :further_information,
-      :ticket_price_info, :ticket_information, :event_date, :event_mode
+      :ticket_price_info, :ticket_information, :event_date, :event_mode,
+      :low_income_requests_start, :low_income_requests_end
     )
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,6 +1,11 @@
 class Event < ApplicationRecord
   has_many :volunteer_roles, dependent: :destroy
   validates :name, presence: true
+  validates :low_income_requests_start, presence: true, if: -> { low_income_requests_end.present? }
+  validates :low_income_requests_end,
+            presence: true,
+            comparison: { greater_than: :low_income_requests_start },
+            if: -> { low_income_requests_start.present? }
 
   enum :event_mode, [:draft, :prerelease, :live, :ended]
 
@@ -17,9 +22,9 @@ class Event < ApplicationRecord
     if are_missing
       false
     else
-      inside_window = !Time.zone.now.before?(low_income_requests_start) &&
-                      !Time.zone.now.after?(low_income_requests_end)
-      inside_window && event_mode == 'prerelease'
+      outside_window = Time.zone.now.before?(low_income_requests_start) ||
+                       Time.zone.now.after?(low_income_requests_end)
+      !outside_window && event_mode == 'prerelease'
     end
   end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -12,6 +12,16 @@ class Event < ApplicationRecord
     end
   end
 
+  def low_income_open?
+    are_missing = !low_income_requests_start.present? && !low_income_requests_end.present?
+    outside_window = Time.zone.now.before?(low_income_requests_start) || Time.zone.now.after?(low_income_requests_end)
+    if are_missing || outside_window
+      false
+    else
+      event_mode == 'prerelease'
+    end
+  end
+
   def eventbrite_start_time
     Date.parse(eventbrite_event.eventbrite_event.start.local)
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -14,11 +14,12 @@ class Event < ApplicationRecord
 
   def low_income_open?
     are_missing = !low_income_requests_start.present? && !low_income_requests_end.present?
-    outside_window = Time.zone.now.before?(low_income_requests_start) || Time.zone.now.after?(low_income_requests_end)
-    if are_missing || outside_window
+    if are_missing
       false
     else
-      event_mode == 'prerelease'
+      inside_window = !Time.zone.now.before?(low_income_requests_start) &&
+                      !Time.zone.now.after?(low_income_requests_end)
+      inside_window && event_mode == 'prerelease'
     end
   end
 

--- a/app/views/admin/events/_form.html.erb
+++ b/app/views/admin/events/_form.html.erb
@@ -1,53 +1,58 @@
 <section>
-<h1>Basic Info</h1>
-<%= form.text_field :name %>
-<%= form.check_box :active %>
-<%= form.select(:event_mode, Event.event_modes.keys.map {|event_mode| [event_mode.titleize, event_mode]}, {}, {:onChange => "checkEventMode();"}) %>
-<% if @event.eventbrite_token.nil? || @event.eventbrite_id.nil? %>
-<div id="missing_eb_warning" class="alert alert-warning" role="alert" style="display: hidden">
-  <p>
-    There is no EventBrite data for this event, so cannot be updated, please contact <%= mail_to "geeks@londondecom.org", "geeks@londondecom.org", subject: "Missing EventBrite Data for Event ID #{@event.id}" %> to get the data added.
-  </p>
-</div>
-<% end %>
+  <h1>Basic Info</h1>
+  <%= form.text_field :name %>
+  <%= form.check_box :active %>
+  <%= form.select(:event_mode, Event.event_modes.keys.map {|event_mode| [event_mode.titleize, event_mode]}, {}, {:onChange => "checkEventMode();"}) %>
+  <% if @event.eventbrite_token.nil? || @event.eventbrite_id.nil? %>
+    <div id="missing_eb_warning" class="alert alert-warning" role="alert" style="display: none">
+      <p>
+        There is no EventBrite data for this event, so cannot be updated, please contact <%= mail_to "geeks@londondecom.org", "geeks@londondecom.org", subject: "Missing EventBrite Data for Event ID #{@event.id}" %> to get the data added.
+      </p>
+    </div>
+  <% end %>
 </section>
 
 <section>
-<h1>Location</h1>
-<%= form.text_field :location %>
-<%= form.text_field :maps_location_url %>
+  <h1>Low Income Tickets</h1>
+  <%= form.datetime_local_field :low_income_requests_start %>
+  <%= form.datetime_local_field :low_income_requests_end %>
 </section>
 
 <section>
-<h1>Date and Time</h1>
-<%= form.datetime_local_field :ticket_sale_start_date %>
-<%= form.text_area :event_timings %>
+  <h1>Location</h1>
+  <%= form.text_field :location %>
+  <%= form.text_field :maps_location_url %>
 </section>
 
 <section>
-<h1>Theme</h1>
-<%= form.text_field :theme %>
-<%= form.text_area :theme_details %>
-<%= form.text_field :theme_image_url %>
+  <h1>Date and Time</h1>
+  <%= form.datetime_local_field :ticket_sale_start_date %>
+  <%= form.text_area :event_timings %>
 </section>
 
 <section>
-<h1>Further Information</h1>
-<%= form.text_area :further_information %>
-<%= form.text_area :ticket_price_info %>
-<%= form.text_area :ticket_information %>
+  <h1>Theme</h1>
+  <%= form.text_field :theme %>
+  <%= form.text_area :theme_details %>
+  <%= form.text_field :theme_image_url %>
+</section>
+
+<section>
+  <h1>Further Information</h1>
+  <%= form.text_area :further_information %>
+  <%= form.text_area :ticket_price_info %>
+  <%= form.text_area :ticket_information %>
 </section>
 
 <script>
-  function checkEventMode(eventMode) {
+  function checkEventMode() {
     <% if @event.eventbrite_token.nil? || @event.eventbrite_id.nil? %>
-    var selection = document.getElementById('event_event_mode');
-    var warning = document.getElementById('missing_eb_warning');
-    var currentValue = selection.value;
-    console.log(currentValue);
-    if (currentValue == "prerelease") {
+    const selection = document.getElementById('event_event_mode');
+    const warning = document.getElementById('missing_eb_warning');
+    const currentValue = selection.value;
+    if (currentValue === "prerelease") {
       warning.style.display = "block";
-    } else if (currentValue == "live") {
+    } else if (currentValue === "live") {
       warning.style.display = "block";
     } else {
       warning.style.display = "none";

--- a/app/views/admin/events/show.html.erb
+++ b/app/views/admin/events/show.html.erb
@@ -1,11 +1,40 @@
-<h1><%= @event.name %></h1>
+<h1>
+  <%= @event.name %>
+  <% if @event.active? %>
+    <span class="badge bg-success">Active</span>
+  <% else %>
+    <span class="badge bg-danger">Inactive</span>
+  <% end %>
+</h1>
 
-<% if @event.live? %>
+<% if @event.live? && @event.active? %>
   <p>Event is currently active (publicly viewable)</p>
+<% elsif @event.live? && !@event.active? %>
+  <p>Event is marked live, but isn't set to be active! (Only those with direct sales or Early Access will be able to see the event)</p>
 <% elsif @event.ended? %>
   <p>Event has ended</p>
 <% else %>
-  <p>Event is currently in <%= @event.event_mode&.titleize %></p>
+  <p>Event is currently in <%= @event.event_mode&.titleize %> mode</p>
+<% end %>
+
+<% if @event.ticket_sale_start_date.present? %>
+  <% if Time.now.utc.before? @event.ticket_sale_start_date %>
+    <p>Ticket sales start in <%= distance_of_time_in_words(Time.zone.now - @event.ticket_sale_start_date) %></p>
+  <% else %>
+    <p>Ticket sales started <%= distance_of_time_in_words(Time.zone.now - @event.ticket_sale_start_date) %> ago</p>
+  <% end %>
+<% end %>
+
+<% if @event.low_income_requests_start.present? && @event.low_income_requests_end.present? %>
+  <% if @event.low_income_open? %>
+    <p>Low income applications are currently open and will close in <%= distance_of_time_in_words(Time.zone.now - @event.low_income_requests_end) %></p>
+  <% else %>
+    <% if Time.zone.now > @event.low_income_requests_end %>
+      <p>Low income application window has closed, you can still however provide people with low income request access</p>
+    <% else %>
+      <p>Low income application window is currently closed, but will open in <%= distance_of_time_in_words(Time.zone.now - @event.low_income_requests_start) %></p>
+    <% end %>
+  <% end %>
 <% end %>
 
 <div class="accordion">
@@ -17,16 +46,38 @@
     </h2>
     <div id="eventDetailsCollapse" class="accordion-collapse collapse show" aria-labelledby="eventHeading" data-bs-parent="#accordionExample">
       <div class="accordion-body">
-        <p>Ticket Sale Start Date: <%= @event.ticket_sale_start_date %></p>
-        <p>Theme: <%= @event.theme %></p>
-        <p>Theme Details: <%= simple_format(@event.theme_details) %></p>
-        <p>Theme Image Url: <%= @event.theme_image_url %></p>
-        <p>Location: <%= @event.location %></p>
-        <p>Maps Location Url: <%= @event.maps_location_url %></p>
-        <p>Event Timings: <%= simple_format(@event.event_timings) %></p>
-        <p>Further Information: <%= simple_format(@event.further_information) %></p>
-        <p>Ticket Price Information: <%= simple_format(@event.ticket_price_info) %></p>
-        <p>Ticket Information: <%= simple_format(@event.ticket_information) %></p>
+        <p>Ticket Sale Start Date: <%= @event.ticket_sale_start_date.present? ? @event.ticket_sale_start_date.to_fs(:decom_standard) : 'No set sale date' %></p>
+        <% if @event.low_income_requests_start.present? && @event.low_income_requests_end.present? %>
+          <p>Low income request window is between <%= @event.low_income_requests_start.to_fs(:decom_standard) %> and <%= @event.low_income_requests_end.to_fs(:decom_standard) %></p>
+        <% else %>
+          <p>No low income request window has been set</p>
+        <% end %>
+        <h2>Theme:</h2>
+        <p><%= @event.theme %></p>
+        <h2>Theme Details:</h2>
+        <p><%= simple_format(@event.theme_details) %></p>
+        <h2>Theme Image Url:</h2>
+        <% if @event.theme_image_url.present? %>
+          <p><%= link_to @event.theme_image_url, @event.theme_image_url %></p>
+        <% else %>
+          <p>No image link provided :(</p>
+        <% end %>
+        <h2>Location:</h2>
+        <p><%= @event.location %></p>
+        <h2>Maps Location Url:</h2>
+        <% if @event.maps_location_url.present? %>
+          <p><%= link_to @event.maps_location_url, @event.maps_location_url %></p>
+        <% else %>
+          <p>No Google Maps link provided :(</p>
+        <% end %>
+        <h2>Event Timings:</h2>
+        <p><%= simple_format(@event.event_timings) %></p>
+        <h2>Further Information:</h2>
+        <p><%= simple_format(@event.further_information) %></p>
+        <h2>Ticket Price Information:</h2>
+        <p><%= simple_format(@event.ticket_price_info) %></p>
+        <h2>Ticket Information:</h2>
+        <p><%= simple_format(@event.ticket_information) %></p>
       </div>
     </div>
   </div>

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -5,7 +5,7 @@
     <% if @event.ticket_sale_start_date.nil? %>
       Tickets for our next event will be available to buy here soon, watch this space!.
     <% else %>
-      Tickets for our next event will be available to buy here on <%= @event.ticket_sale_start_date.strftime("%d/%m/%Y at %I:%M:%S %p") %> (GMT).
+      Tickets for our next event will be available to buy here on <%= @event.ticket_sale_start_date.to_fs(:decom_standard) %> (GMT).
     <% end %>
   <% elsif @event.live? || current_user.early_access %>
     <% if @event.tickets_sold_for_code(current_user.membership_number) > 0 %>
@@ -41,9 +41,8 @@
     <% end %>
   <% end %>
 
-  <%= render partial: '/tickets/low_income' %>
-
   <% if @event.tickets_sold_for_code(current_user.membership_number) == 0 %>
+    <%= render partial: '/tickets/low_income' %>
     <p>
       <strong>
         Bought a transferred ticket and can't see the volunteer opportunities on this page? Drop an email to <a href="mailto:members@londondecom.org">members@londondecom.org</a> and we'll sort you out!

--- a/app/views/tickets/_low_income.html.erb
+++ b/app/views/tickets/_low_income.html.erb
@@ -1,11 +1,17 @@
-<% if current_user.low_income_request %>
-  <% if current_user.low_income_request.status == 'approved' %>
-    <p>Your request for Low Income has been approved. When tickets are available, you will be able to purchase a low income ticket.</p>
-  <% elsif current_user.low_income_request.status == 'rejected' %>
-    <p>Your request for Low Income has been rejected.</p>
+<% if @event && @event.tickets_sold_for_code(current_user.membership_number) == 0 %>
+  <% if current_user.low_income_request %>
+    <% if current_user.low_income_request.status == 'approved' %>
+      <p>Your request for Low Income has been approved. When tickets are available, you will be able to purchase a low income ticket.</p>
+    <% elsif current_user.low_income_request.status == 'rejected' %>
+      <p>Your request for Low Income has been rejected.</p>
+    <% else %>
+      <p>You have applied for a Low Income Ticket. You will be notified when it has been reviewed.</p>
+    <% end %>
+  <% elsif @event.available_tickets_for_code(current_user.membership_number) > 0 && @event.low_income_open? %>
+    <p><%= link_to 'Apply for low income', new_low_income_request_path %></p>
   <% else %>
-    <p>You have applied for a Low Income Ticket. You will be notified when it has been reviewed.</p>
+    <p>Low income applications are not currently open!</p>
   <% end %>
 <% else %>
-  <p>Low income applications have now closed</p>
+  <p>Low income applications are not currently open!</p>
 <% end %>

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,0 +1,1 @@
+Time::DATE_FORMATS[:decom_standard] = '%d/%m/%Y at %I:%M:%S %p'

--- a/db/migrate/20240915235553_low_income_request_window.rb
+++ b/db/migrate/20240915235553_low_income_request_window.rb
@@ -1,0 +1,6 @@
+class LowIncomeRequestWindow < ActiveRecord::Migration[6.1]
+  def change
+    add_column :events, :low_income_requests_start, :datetime
+    add_column :events, :low_income_requests_end, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_09_08_091401) do
+ActiveRecord::Schema[7.2].define(version: 2024_09_15_235553) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -41,6 +41,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_08_091401) do
     t.integer "event_mode"
     t.text "ticket_price_info"
     t.text "ticket_information"
+    t.datetime "low_income_requests_start", precision: nil
+    t.datetime "low_income_requests_end", precision: nil
   end
 
   create_table "low_income_codes", force: :cascade do |t|

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -20,6 +20,8 @@ FactoryBot.define do
     name { 'London Decompression 2019' }
     active { true }
     event_mode { :live }
+    low_income_requests_start { Time.now.utc.advance(weeks: -1) }
+    low_income_requests_end { Time.now.utc.advance(weeks: 1) }
     trait :draft do
       event_mode { :draft }
     end

--- a/spec/features/low_income_spec.rb
+++ b/spec/features/low_income_spec.rb
@@ -40,7 +40,7 @@ RSpec.feature 'Low Income', type: :feature do
 
   scenario 'prerelease event and user has 1 available tickets but the low income window has closed' do
     stub_eventbrite_event(available_tickets_for_code: 1, tickets_sold_for_code: 0)
-    create(:event, :prerelease, low_income_requests_end: Time.zone.now.advance(weeks: -1))
+    create(:event, :prerelease, low_income_requests_end: Time.zone.now.advance(days: -6))
     login
 
     expect(page).to_not have_text('Apply for low income')
@@ -107,7 +107,7 @@ RSpec.feature 'Low Income', type: :feature do
 
   scenario 'live event and user has 1 available tickets but the low income window has closed' do
     stub_eventbrite_event(available_tickets_for_code: 1, tickets_sold_for_code: 0)
-    create(:event, low_income_requests_end: Time.zone.now.advance(weeks: -1))
+    create(:event, low_income_requests_end: Time.zone.now.advance(days: -6))
     login
 
     expect(page).to_not have_text('Apply for low income')

--- a/spec/features/low_income_spec.rb
+++ b/spec/features/low_income_spec.rb
@@ -10,7 +10,6 @@ RSpec.feature 'Low Income', type: :feature do
   end
 
   scenario 'prerelease event and user has 1 available tickets can apply for low income' do
-    pending 'disabled for the year'
     stub_eventbrite_event(available_tickets_for_code: 1, tickets_sold_for_code: 0)
     create(:event, :prerelease)
     login
@@ -26,15 +25,6 @@ RSpec.feature 'Low Income', type: :feature do
     expect(page).to_not have_text('Apply for low income')
   end
 
-  scenario 'live event and user has 1 available tickets can apply for low income' do
-    pending 'disabled for the year'
-    stub_eventbrite_event(available_tickets_for_code: 1, tickets_sold_for_code: 0)
-    create(:event, :live)
-    login
-
-    expect(page).to have_text('Apply for low income')
-  end
-
   scenario 'live event and user has 0 available tickets can no longer apply for low income' do
     stub_eventbrite_event(available_tickets_for_code: 0, tickets_sold_for_code: 1)
     create(:event, :live)
@@ -43,10 +33,9 @@ RSpec.feature 'Low Income', type: :feature do
     expect(page).to_not have_text('Apply for low income')
   end
 
-  scenario 'user has 1 available tickets and bought none' do
-    pending 'disabled for the year'
+  scenario 'user has 1 available tickets and bought none, gets low income approved' do
     stub_eventbrite_event(available_tickets_for_code: 1, tickets_sold_for_code: 0)
-    create(:event)
+    create(:event, :prerelease)
     login
 
     click_link 'Apply for low income', match: :first
@@ -64,6 +53,20 @@ RSpec.feature 'Low Income', type: :feature do
     expect(page).to have_text('Your request for Low Income has been approved.')
     expect(page.html).to include(LowIncomeRequest.last.low_income_code.code)
     expect(page.html).to_not include(User.last.membership_code.code)
+  end
+
+  scenario 'user has 1 available tickets and bought none, gets low income rejected' do
+    stub_eventbrite_event(available_tickets_for_code: 1, tickets_sold_for_code: 0)
+    create(:event, :prerelease)
+    login
+
+    click_link 'Apply for low income', match: :first
+    fill_in 'Please let us know why you believe you need a low income ticket', with: 'My reason'
+    click_button 'Submit request'
+
+    expect(page).to_not have_text('Apply for low income')
+    expect(page).to have_text('You have applied for a Low Income Ticket.')
+    expect(page.html).to include(User.last.membership_code.code)
 
     LowIncomeRequest.last.reject!
 
@@ -71,5 +74,21 @@ RSpec.feature 'Low Income', type: :feature do
 
     expect(page).to have_text('Your request for Low Income has been rejected.')
     expect(page.html).to include(User.last.membership_code.code)
+  end
+
+  scenario 'prerelease event and user has 1 available tickets but the low income window has closed' do
+    stub_eventbrite_event(available_tickets_for_code: 1, tickets_sold_for_code: 0)
+    create(:event, :prerelease, low_income_requests_end: Time.zone.now.advance(weeks: -1))
+    login
+
+    expect(page).to_not have_text('Apply for low income')
+  end
+
+  scenario 'live event and user has 1 available tickets but the low income window has closed' do
+    stub_eventbrite_event(available_tickets_for_code: 1, tickets_sold_for_code: 0)
+    create(:event, low_income_requests_end: Time.zone.now.advance(weeks: -1))
+    login
+
+    expect(page).to_not have_text('Apply for low income')
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,4 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe Event, type: :model do
+  scenario 'trying to set low income start after end' do
+    event = create(:event)
+    event.low_income_requests_end = Time.zone.now
+    event.low_income_requests_start = Time.zone.now.advance(weeks: 1)
+    expect(event).to_not be_valid
+  end
+
+  scenario 'trying to set low income end before start' do
+    event = create(:event)
+    event.low_income_requests_end = Time.zone.now.advance(weeks: -1)
+    event.low_income_requests_start = Time.zone.now
+    expect(event).to_not be_valid
+  end
 end


### PR DESCRIPTION
When handling the low income tickets, instead of it being a manually enabled / disabled thing, we can set a window when the user will be able to apply for low income tickets. It will also automatically be closed if the event is set to anything but `prerelease`.

This is to prevent any issues and gives us a lot more control over things.

There was also an exception thrown when approving low income requests when there were no spare codes, I have added a check for this and it'll add a code in, though this can easily be removed.