### PR TITLE
Scheduler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,5 +86,6 @@ ENV LD_PRELOAD="libjemalloc.so.2" \
 ENTRYPOINT ["/rails/bin/docker-entrypoint"]
 
 # Start the server by default, this can be overwritten at runtime
-EXPOSE 3000
+EXPOSE 8080
+CMD ["whenever --update-crontab"]
 CMD ["./bin/rails", "server"]

--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,8 @@ gem 'postmark-rails'
 
 gem 'recaptcha'
 
+gem 'whenever', require: false
+
 group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'rspec-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,7 @@ GEM
     capybara-email (3.0.2)
       capybara (>= 2.4, < 4.0)
       mail
+    chronic (0.10.2)
     climate_control (1.2.0)
     coffee-rails (5.0.0)
       coffee-script (>= 2.2.0)
@@ -485,6 +486,8 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    whenever (1.0.0)
+      chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.6.18)
@@ -548,6 +551,7 @@ DEPENDENCIES
   web-console (~> 4.2, >= 4.2.1)
   webdrivers (~> 5.3, >= 5.3.1)
   webmock
+  whenever
 
 RUBY VERSION
    ruby 3.3.5p100

--- a/README.md
+++ b/README.md
@@ -205,3 +205,15 @@ When creating the event, you can put an event into Draft without having any Even
 ### Note
 
 The fields `Event Timings`, `Theme Details` and `Further Information` are multiline and will save the line breaks, meaning what you type in the box will be what you get (within reason) on the front end.
+
+## Scheduler
+
+We are now using `whenever` to schedule rake tasks using cron.
+
+Locally you don't need to worry about this, if you do want to test out the cron, simply run `whenever --update-crontab --set environment='development'`
+
+On the server it will automatically run the required command to set up the cron events.
+
+Currently we have the following scheduled tasks running:
+
+`users:purge_old_users` - Runs weekly at 3am, removed any user who hasn't confirmed their account in a year

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,24 @@
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# http://en.wikipedia.org/wiki/Cron
+
+# Example:
+#
+# set :output, "/path/to/my/cron_log.log"
+#
+# every 2.hours do
+#   command "/usr/bin/some_great_command"
+#   runner "MyModel.some_method"
+#   rake "some:great:rake:task"
+# end
+#
+# every 4.days do
+#   runner "AnotherModel.prune_old_records"
+# end
+
+# Learn more: http://github.com/javan/whenever
+
+every 1.week, at: '3:00 am' do
+  rake 'users:purge_old_users'
+end

--- a/lib/tasks/fly.rake
+++ b/lib/tasks/fly.rake
@@ -18,6 +18,7 @@ namespace :fly do
   #  - failures here result in VM being stated, shutdown, and rolled back
   #    to last successful deploy (if any).
   task server: :swapfile do
+    sh 'whenever --update-crontab'
     sh 'bin/rails server'
   end
 

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -1,0 +1,19 @@
+namespace :users do
+  desc "Purge users who haven't been confirmed in a year"
+  task purge_old_users: :environment do
+    purged_users = 0
+    User.unconfirmed.order(created_at: :asc).each do |user|
+      unconfirmed_duration = Time.now - user.confirmation_sent_at.to_time
+      one_year_in_seconds = 31556952
+      next unless unconfirmed_duration >= one_year_in_seconds
+
+      Rollbar.debug('Removing stale user account', email: user.email)
+      user.destroy
+      purged_users += 1
+    end
+
+    Rollbar.info("Executed rake task 'users:purge_old_users'", outcome: "Removed #{purged_users} from the database")
+  rescue StandardError => e
+    Rollbar.error(e)
+  end
+end


### PR DESCRIPTION
Requested by Simon / Hilda

Have a scheduler setup to perform tasks that would otherwise take a lot of time e.g. deleting unconfirmed users over a year old.

I have also cleaned up the rake tasks for eventbrite.

Another useful task possibly to add is clearing down all the low income requests on a yearly basis e.g. Jan 1st.

All run on cron jobs so easy to modify.

Note for the Dockerfile, I have reverted to port 8080 as that is what is spec'd in the fly.toml file and also included the call to `whenever --update-crontab` [Docs](https://github.com/javan/whenever)