### PR TITLE
[User] Prevent MailChimp call if user update fails

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -19,7 +19,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   def update_resource(resource, params)
     result = resource.update_with_password(params)
-    resource.update_mailchimp
+    resource.update_mailchimp if result
     result
   end
 


### PR DESCRIPTION
We were calling MailChimp even if the result of `update_with_password` is false, same for admin side