### PR TITLE
Post Low Income Launch fixes

### DIFF
--- a/app/views/admin/users/unconfirmed.html.erb
+++ b/app/views/admin/users/unconfirmed.html.erb
@@ -1,6 +1,6 @@
 <h2>Unconfirmed Members</h2>
 
-<p>There are currently <%= pluralize(@users.count, 'unconfirmed member') %></p>
+<p>There are currently <%= pluralize(User.unconfirmed.count, 'unconfirmed member') %></p>
 
 <%= form_tag nil, method: :get do %>
   <%= text_field_tag :q, params[:q] %>
@@ -27,3 +27,7 @@
     </tr>
   <% end %>
 </table>
+
+<%= paginate @users, theme: 'twitter-bootstrap-4' %>
+
+<%= link_to 'Confirmed accounts', admin_users_path %>

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -122,7 +122,7 @@
 
   <div class="col-xl-6 col-lg-6 col-md-12 col-sm-12 col-12">
     <p><strong>Where:</strong> <%= @event.location %></p>
-    <p><strong>Map:</strong> <%= link_to 'Google Maps Location', @event.maps_location_url %></p>
+    <p><strong>Map:</strong> <%= link_to 'Google Maps Location', @event.maps_location_url, target: '_blank' %></p>
     <% if @event.eventbrite_event.eventbrite_event.start.local.nil? %>
       <p><strong>When:</strong> <%= simple_format(@event.event_timings) %></p>
     <% else %>
@@ -134,7 +134,7 @@
       <%= simple_format(@event.ticket_price_info) %>
       <%= render partial: '/tickets/low_income' %>
     </p>
-    <p><%= simple_format(@event.ticket_information) %></p>
+    <p><%= simple_format(@event.ticket_information, {}, { sanitize_options: { attributes: %w[target href] }}) %></p>
   </div>
 </div>
 

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -1,11 +1,13 @@
 <h1><%= @event.name %></h1>
 
 <% if @event.prerelease? && !current_user.early_access %>
-  <% if @event.ticket_sale_start_date.nil? %>
-    Tickets for our next event will be available to buy here soon, watch this space!
-  <% else %>
-    Tickets for our next event will be available to buy here on <%= @event.ticket_sale_start_date.to_fs(:decom_standard) %> (GMT).
-  <% end %>
+  <p>
+    <% if @event.ticket_sale_start_date.nil? %>
+      Tickets for our next event will be available to buy here soon, watch this space!
+    <% else %>
+      Tickets for our next event will be available to buy here on <%= @event.ticket_sale_start_date.to_fs(:decom_standard) %> (GMT).
+    <% end %>
+  </p>
 <% elsif @event.live? || current_user.early_access %>
   <% if @event.tickets_sold_for_code(current_user.membership_number) > 0 %>
     <p>
@@ -26,8 +28,7 @@
       <% end %>
     </p>
     <button id="eventbrite-buy-link" type="button" class="btn btn-primary">
-      Buy
-      <%= 'Ticket'.pluralize(@event.available_tickets_for_code(current_user.membership_number)) %>
+      Buy <%= 'Ticket'.pluralize(@event.available_tickets_for_code(current_user.membership_number)) %>
     </button>
     <p><i class="text-muted">By obtaining a ticket, whether purchased directly, gifted, resold or transferred in any way, I consent to my personal information (including sensitive personal data) being processed in line with the Data Protection Act. I consent for this information to be used for event operation, event safety, community safeguarding and consent related purposes including the sharing of information with third parties for these purposes. Where applicable, third parties are also subject to relevant data protection legislation.</i></p>
   <% end %>

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -13,13 +13,6 @@
       <%= pluralize(@event.tickets_sold_for_code(current_user.membership_number), 'ticket') %>
       available to you. Look below to see how you can participate.
     </p>
-  <% elsif current_user.ticket_type != :general %>
-    <button id="eventbrite-buy-link" type="button" class="btn btn-primary">
-      Buy
-      <%= 'Ticket'.pluralize(@event.available_tickets_for_code(current_user.membership_number)) %>
-    </button>
-    <p><i class="text-muted">By obtaining a ticket, whether purchased directly, gifted, resold or transferred in any way, I consent to my personal information (including sensitive personal data) being processed in line with the Data Protection Act. I consent for this information to be used for event operation, event safety, community safeguarding and consent related purposes including the sharing of information with third parties for these purposes. Where applicable, third parties are also subject to relevant data protection legislation.</i></p>
-
   <% else %>
     <p>
       <% if @event.tickets_sold_for_code(current_user.membership_number) > 0 %>

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -1,55 +1,56 @@
 <h1><%= @event.name %></h1>
 
-<p>
-  <% if @event.prerelease? && !current_user.early_access %>
-    <% if @event.ticket_sale_start_date.nil? %>
-      Tickets for our next event will be available to buy here soon, watch this space!.
-    <% else %>
-      Tickets for our next event will be available to buy here on <%= @event.ticket_sale_start_date.to_fs(:decom_standard) %> (GMT).
-    <% end %>
-  <% elsif @event.live? || current_user.early_access %>
-    <% if @event.tickets_sold_for_code(current_user.membership_number) > 0 %>
-      <p>
-        You have bought the
-        <%= pluralize(@event.tickets_sold_for_code(current_user.membership_number), 'ticket') %>
-        available to you. Look below to see how you can participate.
-      </p>
-    <% elsif current_user.ticket_type != :general %>
-      <button id="eventbrite-buy-link" type="button" class="btn btn-primary">
-        Buy
-        <%= 'Ticket'.pluralize(@event.available_tickets_for_code(current_user.membership_number)) %>
-      </button>
-      <p><i class="text-muted">By obtaining a ticket, whether purchased directly, gifted, resold or transferred in any way, I consent to my personal information (including sensitive personal data) being processed in line with the Data Protection Act. I consent for this information to be used for event operation, event safety, community safeguarding and consent related purposes including the sharing of information with third parties for these purposes. Where applicable, third parties are also subject to relevant data protection legislation.</i></p>
-
-    <% else %>
-      <p style="margin-bottom: 0">
-        <% if @event.tickets_sold_for_code(current_user.membership_number) > 0 %>
-          You have already bought
-          <%= pluralize(@event.tickets_sold_for_code(current_user.membership_number), 'ticket') %>.
-          You can buy
-          <%= pluralize(@event.available_tickets_for_code(current_user.membership_number), 'more ticket') %>.
-        <% else %>
-          You can buy
-          <%= pluralize(@event.available_tickets_for_code(current_user.membership_number), 'ticket') %>.
-        <% end %>
-      </p>
-      <button id="eventbrite-buy-link" type="button" class="btn btn-primary">
-        Buy
-        <%= 'Ticket'.pluralize(@event.available_tickets_for_code(current_user.membership_number)) %>
-      </button>
-      <p><i class="text-muted">By obtaining a ticket, whether purchased directly, gifted, resold or transferred in any way, I consent to my personal information (including sensitive personal data) being processed in line with the Data Protection Act. I consent for this information to be used for event operation, event safety, community safeguarding and consent related purposes including the sharing of information with third parties for these purposes. Where applicable, third parties are also subject to relevant data protection legislation.</i></p>
-    <% end %>
+<% if @event.prerelease? && !current_user.early_access %>
+  <% if @event.ticket_sale_start_date.nil? %>
+    Tickets for our next event will be available to buy here soon, watch this space!
+  <% else %>
+    Tickets for our next event will be available to buy here on <%= @event.ticket_sale_start_date.to_fs(:decom_standard) %> (GMT).
   <% end %>
+<% elsif @event.live? || current_user.early_access %>
+  <% if @event.tickets_sold_for_code(current_user.membership_number) > 0 %>
+    <p>
+      You have bought the
+      <%= pluralize(@event.tickets_sold_for_code(current_user.membership_number), 'ticket') %>
+      available to you. Look below to see how you can participate.
+    </p>
+  <% elsif current_user.ticket_type != :general %>
+    <button id="eventbrite-buy-link" type="button" class="btn btn-primary">
+      Buy
+      <%= 'Ticket'.pluralize(@event.available_tickets_for_code(current_user.membership_number)) %>
+    </button>
+    <p><i class="text-muted">By obtaining a ticket, whether purchased directly, gifted, resold or transferred in any way, I consent to my personal information (including sensitive personal data) being processed in line with the Data Protection Act. I consent for this information to be used for event operation, event safety, community safeguarding and consent related purposes including the sharing of information with third parties for these purposes. Where applicable, third parties are also subject to relevant data protection legislation.</i></p>
 
-  <% if @event.tickets_sold_for_code(current_user.membership_number) == 0 %>
-    <%= render partial: '/tickets/low_income' %>
+  <% else %>
+    <p>
+      <% if @event.tickets_sold_for_code(current_user.membership_number) > 0 %>
+        You have already bought
+        <%= pluralize(@event.tickets_sold_for_code(current_user.membership_number), 'ticket') %>.
+        You can buy
+        <%= pluralize(@event.available_tickets_for_code(current_user.membership_number), 'more ticket') %>.
+      <% else %>
+        You can buy
+        <%= pluralize(@event.available_tickets_for_code(current_user.membership_number), 'ticket') %>.
+      <% end %>
+    </p>
+    <button id="eventbrite-buy-link" type="button" class="btn btn-primary">
+      Buy
+      <%= 'Ticket'.pluralize(@event.available_tickets_for_code(current_user.membership_number)) %>
+    </button>
+    <p><i class="text-muted">By obtaining a ticket, whether purchased directly, gifted, resold or transferred in any way, I consent to my personal information (including sensitive personal data) being processed in line with the Data Protection Act. I consent for this information to be used for event operation, event safety, community safeguarding and consent related purposes including the sharing of information with third parties for these purposes. Where applicable, third parties are also subject to relevant data protection legislation.</i></p>
+  <% end %>
+<% end %>
+
+<% if @event.tickets_sold_for_code(current_user.membership_number) == 0 %>
+  <%= render partial: '/tickets/low_income' %>
+
+  <% if @event.live? || current_user.early_access %>
     <p>
       <strong>
         Bought a transferred ticket and can't see the volunteer opportunities on this page? Drop an email to <a href="mailto:members@londondecom.org">members@londondecom.org</a> and we'll sort you out!
       </strong>
     </p>
   <% end %>
-</p>
+<% end %>
 
 <% if @event.tickets_sold_for_code(current_user.membership_number) > 0 %>
   <hr />
@@ -82,6 +83,7 @@
       <% end %>
 
       <hr />
+    </div>
   <% end %>
 
   <% if current_user.volunteers_for_event(@event).any? %>
@@ -114,14 +116,14 @@
 
 <hr>
 
-<p>Here is the crucial info</p>
+<h2>Here is the crucial info</h2>
 <% if @event.theme_image_url.present? %>
   <%= image_tag @event.theme_image_url, style: 'width: 100%;' %>
 <% end %>
 
 <div class="row mt-3">
   <div class="col-xl-6 col-lg-6 col-md-12 col-sm-12 col-12">
-    <p><strong><%= @event.name %>: <%= @event.theme %></strong></p>
+    <h3><strong><%= @event.name %>: <%= @event.theme %></strong></h3>
     <%= simple_format(@event.theme_details) %>
   </div>
 


### PR DESCRIPTION
Something got lost in a shuffle, this just restores the correct counter for unconfirmed users at all time, in the same way the confirmed user page does.

Also providing a link back to the confirmed user accounts at the bottom of the page.

Rolled in also: 

Request came in to hide the transfer ticket text.

Cleaned up some branching, cleaned up some mssing tags and prevented rails from messing up some of the links we had in one section (ticket_information)
